### PR TITLE
[修正PR]推し作成処理にトランザクション管理でデータ整合性を改善

### DIFF
--- a/internal/models/oshi.go
+++ b/internal/models/oshi.go
@@ -33,7 +33,7 @@ type OshiResponse struct {
 // 推し作成リクエスト
 type CreateOshiRequest struct {
 	Name       string   `json:"name" validate:"required"`
-	Color      string   `json:"color" validate:"required",startswith=#",len=7`
+	Color      string   `json:"color" validate:"required,startswith=#,len=7"`
 	URLs       []string `json:"urls"`
 	Categories []string `json:"categories"`
 }


### PR DESCRIPTION
## 概要
推し新規作成処理において、トランザクション管理を導入

## 問題
推し作成、アカウント追加、カテゴリ追加が独立したDB操作として実行されていた
- カテゴリが存在しない場合、推しとアカウントは作成されるがカテゴリのみ失敗する

## 解決策
### トランザクション管理の実装
- `CreateOshiWithTransaction`メソッドを新規追加
- 推し作成、アカウント追加、カテゴリ追加を単一トランザクション内で実行
- エラー時のロールバック処理を実装