### PR TITLE
add get all events by user api

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,6 +33,10 @@ func main() {
 	commonService := service.NewCommonService(categoryRepo)
 	commonHandler := handler.NewCommonHandler(commonService)
 
+	eventsRepo := repository.NewEventsRepository(db)
+	eventsService := service.NewEventsService(eventsRepo)
+	eventsHandler := handler.NewEventsHandler(eventsService)
+
 	// Echo インスタンスを作成
 	e := echo.New()
 
@@ -42,7 +46,7 @@ func main() {
 	e.Use(middleware.CORS())
 
 	// ルート設定
-	routes.SetupRoutes(e, userHandler, oshiHandler, commonHandler)
+	routes.SetupRoutes(e, userHandler, oshiHandler, commonHandler, eventsHandler)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/internal/handler/events_handler.go
+++ b/internal/handler/events_handler.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"lovender_backend/internal/service"
+	"lovender_backend/pkg/jwtutil"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type EventsHandler struct {
+	eventsService service.EventsService
+}
+
+func NewEventsHandler(eventsService service.EventsService) *EventsHandler {
+	return &EventsHandler{
+		eventsService: eventsService,
+	}
+}
+
+func (h EventsHandler) GetMyOshiEvents(c echo.Context) error {
+	// JWTトークンからユーザー情報を取得
+	claims, err := jwtutil.ExtractUser(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Invalid token"})
+	}
+
+	userID := int64(claims.UserID)
+
+	// ユーザーの登録した各推しのイベントを全て取得
+	events, err := h.eventsService.GetUserOshiEvents(userID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Internal server error"})
+	}
+
+	return c.JSON(http.StatusOK, events)
+}

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -1,0 +1,37 @@
+package models
+
+import "time"
+
+// 推しのイベント情報レスポンス
+type OshiEventsResponse struct {
+	Oshis []OshiEventsResponseItem `json:"oshis"`
+}
+
+// 推しのイベント情報レスポンス内の各推し情報
+type OshiEventsResponseItem struct {
+	ID     int64       `json:"id"`
+	Name   string      `json:"name"`
+	Color  string      `json:"color"`
+	Events []EventItem `json:"events"`
+}
+
+// 各推しのイベント情報
+type EventItem struct {
+	ID                    int64          `json:"id"`
+	Title                 string         `json:"title"`
+	Description           *string        `json:"description"`
+	URL                   []string       `json:"url"`
+	Starts_at             time.Time      `json:"starts_at"`
+	Ends_at               time.Time      `json:"ends_at"`
+	Has_alarm             bool           `json:"has_alarm"`
+	Notification_timing   string         `json:"notification_timing"`
+	Has_notification_sent bool           `json:"has_notification_sent"`
+	Category              []CategoryItem `json:"category"`
+}
+
+// 各推しのイベントのカテゴリ情報
+type CategoryItem struct {
+	ID   int64  `json:"id"`
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+}

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -2,31 +2,18 @@ package models
 
 import "time"
 
-// 推しのイベント情報レスポンス
-type OshiEventsResponse struct {
-	Oshis []OshiEventsResponseItem `json:"oshis"`
-}
-
-// 推しのイベント情報レスポンス内の各推し情報
-type OshiEventsResponseItem struct {
-	ID     int64       `json:"id"`
-	Name   string      `json:"name"`
-	Color  string      `json:"color"`
-	Events []EventItem `json:"events"`
-}
-
 // 各推しのイベント情報
-type EventItem struct {
-	ID                    int64          `json:"id"`
-	Title                 string         `json:"title"`
-	Description           *string        `json:"description"`
-	URL                   []string       `json:"url"`
-	Starts_at             time.Time      `json:"starts_at"`
-	Ends_at               time.Time      `json:"ends_at"`
-	Has_alarm             bool           `json:"has_alarm"`
-	Notification_timing   string         `json:"notification_timing"`
-	Has_notification_sent bool           `json:"has_notification_sent"`
-	Category              []CategoryItem `json:"category"`
+type Event struct {
+	ID                    int64         `json:"id"`
+	Title                 string        `json:"title"`
+	Description           *string       `json:"description"`
+	URL                   *string       `json:"url"`
+	Starts_at             time.Time     `json:"starts_at"`
+	Ends_at               *time.Time    `json:"ends_at"`
+	Has_alarm             bool          `json:"has_alarm"`
+	Notification_timing   string        `json:"notification_timing"`
+	Has_notification_sent bool          `json:"has_notification_sent"`
+	Category              *CategoryItem `json:"category"`
 }
 
 // 各推しのイベントのカテゴリ情報
@@ -34,4 +21,17 @@ type CategoryItem struct {
 	ID   int64  `json:"id"`
 	Slug string `json:"slug"`
 	Name string `json:"name"`
+}
+
+// 推しのイベント情報レスポンス
+type OshiEventsResponse struct {
+	Oshis []OshiEventsResponseItem `json:"oshis"`
+}
+
+// 推しのイベント情報レスポンス内の各推し情報
+type OshiEventsResponseItem struct {
+	ID     int64   `json:"id"`
+	Name   string  `json:"name"`
+	Color  string  `json:"color"`
+	Events []Event `json:"events"`
 }

--- a/internal/repository/events_repository.go
+++ b/internal/repository/events_repository.go
@@ -1,0 +1,24 @@
+package repository
+
+import (
+	"database/sql"
+	"lovender_backend/internal/models"
+)
+
+type EventsRepository interface {
+	GetOshiEventsByUserID(userID int64) (*models.OshiEventsResponse, error)
+}
+
+type eventsRepository struct {
+	db *sql.DB
+}
+
+func NewEventsRepository(db *sql.DB) EventsRepository {
+	return &eventsRepository{db: db}
+}
+
+func (r *eventsRepository) GetOshiEventsByUserID(userID int64) (*models.OshiEventsResponse, error) {
+	return &models.OshiEventsResponse{
+		Oshis: make([]models.OshiEventsResponseItem, 0),
+	}, nil
+}

--- a/internal/repository/events_repository.go
+++ b/internal/repository/events_repository.go
@@ -2,7 +2,9 @@ package repository
 
 import (
 	"database/sql"
+	"fmt"
 	"lovender_backend/internal/models"
+	"time"
 )
 
 type EventsRepository interface {
@@ -18,7 +20,130 @@ func NewEventsRepository(db *sql.DB) EventsRepository {
 }
 
 func (r *eventsRepository) GetOshiEventsByUserID(userID int64) (*models.OshiEventsResponse, error) {
-	return &models.OshiEventsResponse{
+	query := fmt.Sprintf(`
+		SELECT
+			o.id as oshi_id,
+			o.name as oshi_name,
+			o.theme_color,
+			e.id as event_id,
+			e.title as event_title,
+			e.description as event_description,
+			e.url as event_url,
+			e.starts_at as event_starts_at,
+			e.ends_at as event_ends_at,
+			e.has_alarm as event_has_alarm,
+			e.notification_timing as event_notification_timing,
+			e.has_notification_sent as event_has_notification_sent,
+			c.id as category_id,
+			c.slug as category_slug,
+			c.name as category_name
+		FROM oshis o
+		LEFT JOIN events e ON o.id = e.oshi_id
+		LEFT JOIN categories c ON e.category_id = c.id
+		WHERE o.user_id = %d
+		ORDER BY o.id ASC, e.starts_at ASC, e.id ASC
+	`, userID)
+
+	rows, err := r.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	response := &models.OshiEventsResponse{
 		Oshis: make([]models.OshiEventsResponseItem, 0),
-	}, nil
+	}
+	indexByOshi := make(map[int64]int)
+
+	for rows.Next() {
+		var (
+			oshiID                   int64
+			oshiName                 string
+			themeColor               string
+			eventID                  *int64
+			eventTitle               *string
+			eventDescription         *string
+			eventURL                 *string
+			eventStartsAt            *time.Time
+			eventEndsAt              *time.Time
+			eventHasAlarm            *bool
+			eventNotificationTiming  *string
+			eventHasNotificationSent *bool
+			categoryID               *int64
+			categorySlug             *string
+			categoryName             *string
+		)
+
+		err := rows.Scan(
+			&oshiID, &oshiName, &themeColor,
+			&eventID, &eventTitle, &eventDescription, &eventURL, &eventStartsAt, &eventEndsAt,
+			&eventHasAlarm, &eventNotificationTiming, &eventHasNotificationSent,
+			&categoryID, &categorySlug, &categoryName,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		// --- 推しバケット確保 ---
+		index, exists := indexByOshi[oshiID]
+		if !exists {
+			response.Oshis = append(response.Oshis, models.OshiEventsResponseItem{
+				ID:     oshiID,
+				Name:   oshiName,
+				Color:  themeColor,
+				Events: make([]models.Event, 0),
+			})
+			index = len(response.Oshis) - 1
+			indexByOshi[oshiID] = index
+		}
+
+		// イベントが無い行はスキップ（LEFT JOINの空振り）
+		if eventID == nil {
+			continue
+		}
+
+		// Category: あれば詰める
+		var category *models.CategoryItem
+		if categoryID != nil && categorySlug != nil && categoryName != nil {
+			category = &models.CategoryItem{
+				ID:   *categoryID,
+				Slug: *categorySlug,
+				Name: *categoryName,
+			}
+		}
+
+		// モデルへ整形（nilは安全なデフォルトに落とす）
+		event := models.Event{
+			ID:                    *eventID,
+			Title:                 *eventTitle,
+			Description:           eventDescription,
+			URL:                   eventURL,
+			Starts_at:             *eventStartsAt,
+			Ends_at:               eventEndsAt,
+			Has_alarm:             *eventHasAlarm,
+			Notification_timing:   *eventNotificationTiming,
+			Has_notification_sent: *eventHasNotificationSent,
+			Category:              category,
+		}
+
+		// ここまでで idx と ev（models.Event）ができている前提
+		dup := false
+		for _, existing := range resp.Oshis[idx].Events {
+			if existing.ID == ev.ID {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			resp.Oshis[idx].Events = append(resp.Oshis[idx].Events, ev)
+		}
+
+		response.Oshis[index].Events = append(response.Oshis[index].Events, event)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return response, nil
 }

--- a/internal/repository/events_repository.go
+++ b/internal/repository/events_repository.go
@@ -127,19 +127,17 @@ func (r *eventsRepository) GetOshiEventsByUserID(userID int64) (*models.OshiEven
 			Category:              category,
 		}
 
-		// ここまでで idx と ev（models.Event）ができている前提
-		dup := false
-		for _, existing := range resp.Oshis[idx].Events {
-			if existing.ID == ev.ID {
-				dup = true
+		// 重複チェック
+		found := false
+		for _, existing := range response.Oshis[index].Events {
+			if existing.ID == event.ID {
+				found = true
 				break
 			}
 		}
-		if !dup {
-			resp.Oshis[idx].Events = append(resp.Oshis[idx].Events, ev)
+		if !found {
+			response.Oshis[index].Events = append(response.Oshis[index].Events, event)
 		}
-
-		response.Oshis[index].Events = append(response.Oshis[index].Events, event)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func SetupRoutes(e *echo.Echo, userHandler *handler.UserHandler, oshiHandler *handler.OshiHandler, commonHandler *handler.CommonHandler) {
+func SetupRoutes(e *echo.Echo, userHandler *handler.UserHandler, oshiHandler *handler.OshiHandler, commonHandler *handler.CommonHandler, eventsHandler *handler.EventsHandler) {
 	// API ルート
 	api := e.Group("/api")
 
@@ -23,6 +23,7 @@ func SetupRoutes(e *echo.Echo, userHandler *handler.UserHandler, oshiHandler *ha
 	protected.Use(jwtutil.JWTMiddleware())
 	protected.GET("/oshis", oshiHandler.GetMyOshis)
 	protected.POST("/oshis", oshiHandler.CreateOshi)
+	protected.GET("/events", eventsHandler.GetMyOshiEvents)
 	protected.PUT("/oshis/:oshiId", oshiHandler.UpdateOshi)
 
 	// API接続テスト用のユーザー情報取得

--- a/internal/service/events_service.go
+++ b/internal/service/events_service.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"lovender_backend/internal/models"
+	"lovender_backend/internal/repository"
+)
+
+type EventsService interface {
+	GetUserOshiEvents(userID int64) (*models.OshiEventsResponse, error)
+}
+type eventsService struct {
+	eventsRepo repository.EventsRepository
+}
+
+func NewEventsService(eventsRepo repository.EventsRepository) EventsService {
+	return &eventsService{eventsRepo: eventsRepo}
+}
+
+func (s *eventsService) GetUserOshiEvents(userID int64) (*models.OshiEventsResponse, error) {
+
+	return &models.OshiEventsResponse{
+		Oshis: make([]models.OshiEventsResponseItem, 0),
+	}, nil
+}

--- a/internal/service/events_service.go
+++ b/internal/service/events_service.go
@@ -17,8 +17,10 @@ func NewEventsService(eventsRepo repository.EventsRepository) EventsService {
 }
 
 func (s *eventsService) GetUserOshiEvents(userID int64) (*models.OshiEventsResponse, error) {
+	events, err := s.eventsRepo.GetOshiEventsByUserID(userID)
+	if err != nil {
+		return nil, err
+	}
 
-	return &models.OshiEventsResponse{
-		Oshis: make([]models.OshiEventsResponseItem, 0),
-	}, nil
+	return events, nil
 }


### PR DESCRIPTION
# 概要
- userの推しと関連するイベントを全て取得する
- 各推しのevents配列内で時系列順にソートされている
# ISSUE
#14
# 動作確認
### 成功
<img width="1849" height="385" alt="image" src="https://github.com/user-attachments/assets/6593ac2d-d67c-4afe-9fe2-a7a8a3529c93" />

<img width="1571" height="832" alt="image" src="https://github.com/user-attachments/assets/eace72ab-2626-4c7e-909a-f1ac56c0a7d4" />

### 失敗(アクセストークンのミス)
<img width="1886" height="746" alt="image" src="https://github.com/user-attachments/assets/ef9a74b5-b62c-4235-863a-6fe1581ca084" />
