### PR TITLE
add get event by id

### DIFF
--- a/internal/handler/events_handler.go
+++ b/internal/handler/events_handler.go
@@ -4,6 +4,7 @@ import (
 	"lovender_backend/internal/service"
 	"lovender_backend/pkg/jwtutil"
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -34,4 +35,36 @@ func (h EventsHandler) GetMyOshiEvents(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, events)
+}
+
+// 特定のイベント詳細を取得
+func (h EventsHandler) GetEventByID(c echo.Context) error {
+	// JWTトークンからユーザー情報を取得
+	claims, err := jwtutil.ExtractUser(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Invalid token"})
+	}
+
+	// パスパラメータからeventIdを取得
+	eventIDStr := c.Param("eventId")
+	eventID, err := strconv.ParseInt(eventIDStr, 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid event ID"})
+	}
+
+	userID := int64(claims.UserID)
+
+	// イベント詳細を取得
+	event, err := h.eventsService.GetEventByID(eventID, userID)
+	if err != nil {
+		if err.Error() == "event not found" {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Event not found"})
+		}
+		if err.Error() == "access denied" {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "Access denied"})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Internal server error"})
+	}
+
+	return c.JSON(http.StatusOK, event)
 }

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -35,3 +35,29 @@ type OshiEventsResponseItem struct {
 	Color  string  `json:"color"`
 	Events []Event `json:"events"`
 }
+
+// イベント詳細情報
+type EventDetail struct {
+	ID                    int64            `json:"id"`
+	Title                 string           `json:"title"`
+	Description           *string          `json:"description"`
+	URL                   *string          `json:"url"`
+	Starts_at             time.Time        `json:"starts_at"`
+	Ends_at               *time.Time       `json:"ends_at"`
+	Has_alarm             bool             `json:"has_alarm"`
+	Notification_timing   string           `json:"notification_timing"`
+	Has_notification_sent bool             `json:"has_notification_sent"`
+	Oshi                  EventOshi        `json:"oshi"`
+}
+
+// イベント詳細レスポンス用の推し情報
+type EventOshi struct {
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// イベント詳細レスポンス
+type EventDetailResponse struct {
+	Event EventDetail `json:"event"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -23,8 +23,9 @@ func SetupRoutes(e *echo.Echo, userHandler *handler.UserHandler, oshiHandler *ha
 	protected.Use(jwtutil.JWTMiddleware())
 	protected.GET("/oshis", oshiHandler.GetMyOshis)
 	protected.POST("/oshis", oshiHandler.CreateOshi)
-	protected.GET("/events", eventsHandler.GetMyOshiEvents)
 	protected.PUT("/oshis/:oshiId", oshiHandler.UpdateOshi)
+	protected.GET("/events", eventsHandler.GetMyOshiEvents)
+	protected.GET("/events/:eventId", eventsHandler.GetEventByID)
 
 	// API接続テスト用のユーザー情報取得
 	api.GET("/users/:id", userHandler.GetUser)

--- a/internal/service/events_service.go
+++ b/internal/service/events_service.go
@@ -7,6 +7,7 @@ import (
 
 type EventsService interface {
 	GetUserOshiEvents(userID int64) (*models.OshiEventsResponse, error)
+	GetEventByID(eventID int64, userID int64) (*models.EventDetailResponse, error)
 }
 type eventsService struct {
 	eventsRepo repository.EventsRepository
@@ -23,4 +24,16 @@ func (s *eventsService) GetUserOshiEvents(userID int64) (*models.OshiEventsRespo
 	}
 
 	return events, nil
+}
+
+func (s *eventsService) GetEventByID(eventID int64, userID int64) (*models.EventDetailResponse, error) {
+	// イベント詳細を取得
+	eventDetail, err := s.eventsRepo.GetEventByIDWithOshi(eventID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.EventDetailResponse{
+		Event: *eventDetail,
+	}, nil
 }


### PR DESCRIPTION
# 概要
- 特定のイベントIDから詳細情報を取得
- レスポンス: イベント情報 + 推し基本情報
# リクエスト
## エンドポイント
```
GET /api/me/events/{eventId}
```
ヘッダー
```
Authorization: Bearer <access_token>
```
# レスポンス例
200
```
{
  "event": {
    "id": 1001,
    "title": "ライブツアー2024 東京公演",
    "description": "年に一度の大型ライブイベントです",
    "url": "https://example.com/events/1001",
    "starts_at": "2024-03-15T19:00:00Z",
    "ends_at": "2024-03-15T22:00:00Z",
    "has_alarm": true,
    "notification_timing": "15m",
    "has_notification_sent": false,
    "oshi": {
      "id": 38,
      "name": "推しちゃん",
      "color": "#FF6B9D"
    }
  }
}
```
# 動作確認
<img width="1067" height="636" alt="image" src="https://github.com/user-attachments/assets/dacd3fd9-0878-41fc-bcb2-8fad4550b211" />


